### PR TITLE
Fix broken links in reports

### DIFF
--- a/doc/report2/README.md
+++ b/doc/report2/README.md
@@ -1,22 +1,23 @@
 # Synthetic network for Docker containers
 
 We’ve added a few more apps
-([Delay](https://github.com/daily-co/synthetic-network/pull/2),
-[Jitter, and RateLimiter](https://github.com/daily-co/synthetic-network/pull/6)),
+([Latency](https://github.com/daily-co/synthetic-network/blob/main/rush/src/qos.rs#L47-L90),
+[Jitter](https://github.com/daily-co/synthetic-network/blob/main/rush/src/qos.rs#L92-L151),
+and [RateLimiter](https://github.com/daily-co/synthetic-network/blob/main/rush/src/qos.rs#L221-L319)),
 moved our playground `main()` function into a basic
-[program](https://github.com/daily-co/synthetic-network/pull/7),
+[program](https://github.com/daily-co/synthetic-network/blob/main/rush/src/synthetic_network.rs#L31-L66),
 and added a fledgling
-[frontend](https://github.com/daily-co/synthetic-network/pull/9)
+[frontend](https://github.com/daily-co/synthetic-network/tree/main/frontend)
 to control our synthetic network.
 
-We also sketched a [Dockerfile](https://github.com/daily-co/synthetic-network/pull/3)
+We also sketched a [Dockerfile](https://github.com/daily-co/synthetic-network/blob/main/Dockerfile)
 that builds an image providing a synthetic network to applications running
 within.
 
-None of this worked on the first try, and we’re integrating all those
+~~None of this worked on the first try, and we’re integrating all those
 components and debugging them on the
-[daily-frontend-integrate](https://github.com/daily-co/synthetic-network/tree/daily-frontend-integrate)
-branch. Checkout this branch to follow along the examples below.
+`daily-frontend-integrate`
+branch. Checkout this branch to follow along the examples below.~~
 
 ## The synthetic network program
 

--- a/doc/report3/README.md
+++ b/doc/report3/README.md
@@ -63,7 +63,7 @@ separate quality of service settings we extended the graph as shown below.
 
 ![Synthetic network with flows](FlowsApps/page02.jpg)
 
-The new [Split](https://github.com/daily-co/synthetic-network/blob/15556d0e500197759c2499cd242aa58d2383f704/src/flow.rs#L12)
+The new [Split](https://github.com/daily-co/synthetic-network/blob/main/rush/src/flow.rs#L16-L101)
 app does the heavy lifting, parsing protocol headers and
 distributing packets to its output links accordingly. At each of its outputs
 there sits a dedicated chain of traffic conditioning apps that can be
@@ -95,9 +95,8 @@ pub struct UDP {
 
 ## Bonus: Checksums
 
-We nipped [#5](https://github.com/daily-co/synthetic-network/issues/5) in the
-bud (at least for IPv4) by reviving `checksum.rs` and adding the
-[Checksum](https://github.com/daily-co/synthetic-network/blob/15556d0e500197759c2499cd242aa58d2383f704/src/offload.rs#L13)
+We ~~nipped #5 in the bud~~ fixed a checksum offload interoperability issue with Linux (at least for IPv4) by reviving `checksum.rs` and adding the
+[Checksum](https://github.com/daily-co/synthetic-network/blob/main/rush/src/offload.rs#L15-L96)
 app.
 
 That app opportunistically detects packets where Linux omitted to calculate
@@ -110,8 +109,8 @@ To make the fruits of our labor easily consumable we added a `Makefile` to the
 top-level of the repository. That `Makefile` should make one hopefully useful
 tool for ad-hoc testing trivially available to Daily hackers: a [Chrome browser
 with configurable synthetic network exposed over
-VNC](https://github.com/daily-co/synthetic-network/pull/20). To try that you
-can:
+VNC](https://github.com/daily-co/synthetic-network#run-chrome-using-synthetic-network-in-vnc).
+To try that you can:
 
 > Setup the synthetic network (you only need to do this once)
 ```
@@ -139,7 +138,7 @@ behavior that depends on averse network conditions.
 
 ## Under the hood
 
-You can take a peek at [synth-chrome/Dockerfile](https://github.com/daily-co/synthetic-network/blob/fadd183b1edf38ee92afe714de96e84ba39c7cc3/synth-chrome/Dockerfile)
+You can take a peek at [synth-chrome/Dockerfile](https://github.com/daily-co/synthetic-network/blob/main/synth-chrome/Dockerfile)
 to see how we build the Chrome container. In a nutshell:
 
 - We build a `syntheticnet:vnc` image with VNC enabled, see `make image-vnc`.

--- a/doc/report4/README.md
+++ b/doc/report4/README.md
@@ -19,7 +19,7 @@ sliders affect the obsered network activity.
 
 ## Implementation
 
-(See the [flow::Top app](https://github.com/daily-co/synthetic-network/blob/2dda5b8187e61868a92cd2d065f705b65a644509/rush/src/flow.rs#L104-L258))
+(See the [flow::Top app](https://github.com/daily-co/synthetic-network/blob/main/rush/src/flow.rs#L104-L263))
 
 The way this is implemented is that the Synthetic Network backend—our
 userspace packet forwarding engine—maintains profiles counting all the packets
@@ -114,4 +114,4 @@ for (var flow in ingress_profile.flows)
 ```
 
 For a complete example of scripting the synthetic network you can take a look
-at [frontend/udp_rate_sine_demo.js](https://github.com/daily-co/synthetic-network/blob/ee21576f7edf79f63ee220e1fcb4212126e7b668/frontend/udp_rate_sine_demo.js).
+at [frontend/udp_rate_sine_demo.js](https://github.com/daily-co/synthetic-network/blob/main/frontend/udp_rate_sine_demo.js).


### PR DESCRIPTION
This updates some hyperlinks into the old repository to point to matching valid locations in the new repo.

Cc @vipyne 