### PR TITLE
use chromium instead of google-chrome-stable on arm64

### DIFF
--- a/synth-chrome/Dockerfile
+++ b/synth-chrome/Dockerfile
@@ -12,7 +12,7 @@ RUN ARCH=`uname -m` ; if [ "$ARCH" = "aarch64" ] ; then \
 
 ENV USE_VNC=yes
 
-ENV ENTRY="chromium \
+ENV ENTRY="google-chrome-stable \
     --no-sandbox --disable-gpu --no-first-run \ 
     --disable-dev-shm-usage --disable-sync \
     --autoplay-policy=no-user-gesture-required  \

--- a/synth-chrome/Dockerfile
+++ b/synth-chrome/Dockerfile
@@ -1,10 +1,18 @@
 FROM syntheticnet:vnc
 
-RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN dpkg -i google-chrome-stable_current_amd64.deb || apt-get --fix-broken install -y
+RUN ARCH=`uname -m` ; if [ "$ARCH" = "aarch64" ] ; then \
+    echo "installing chromium for aarch64" ; \
+    apt-get --fix-broken install -y chromium ; \
+    ln -s /usr/bin/chromium /usr/bin/google-chrome-stable ; \
+  else \
+    echo "installing google-chrome-stable" ; \
+    wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb ; \
+    dpkg -i google-chrome-stable_current_amd64.deb || apt-get --fix-broken install -y ; \
+  fi
 
 ENV USE_VNC=yes
-ENV ENTRY="google-chrome-stable \
+
+ENV ENTRY="chromium \
     --no-sandbox --disable-gpu --no-first-run \ 
     --disable-dev-shm-usage --disable-sync \
     --autoplay-policy=no-user-gesture-required  \


### PR DESCRIPTION
It appears that google-chrome-stable is not available for arm64 linux. On an M1 macOS machine our Docker VMs are arm64 arch, so this patch replaces google-chrome-stable with Chromium.

And also symlinks `/usr/bin/google-chrome-stable` to `/usr/bin/chromium`. I'm sorry.