### PR TITLE
add new Makefile target "minimal"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 ENV PATH=${PATH}:/root/.cargo/bin
 
 # Add and build rush (synthetic network backend / userspace proxy)
-ADD rush /opt/lib/rush
-WORKDIR /opt/lib/rush
+ADD rush /opt/src/rush
+WORKDIR /opt/src/rush
 RUN cargo build --release
+RUN cp /opt/src/rush/target/release/rush /opt/lib/rush
 
 # Add frontend (synthetic network web UI)
 ADD frontend /opt/lib/frontend

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,13 @@
+FROM ubuntu:22.04
+
+# Linux networking tools
+RUN apt-get update && apt-get install -y \
+    iproute2 ethtool iputils-ping iperf3 lsof tcpdump net-tools
+
+# Add rush (synthetic network backend / userspace proxy)
+COPY rush/target/release/rush /opt/lib/rush
+
+# Entrypoint / test setup
+ADD setup.sh /opt/lib/
+WORKDIR /opt/lib
+CMD ["/opt/lib/setup.sh"]

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ image-vnc: # Build Docker image: syntheticnet:vnc
 image-chrome: image-vnc # Build Docker image: syntheticnet:chrome
 	$(DOCKER) build -t syntheticnet:chrome synth-chrome/
 
+rush: # Build rush
+	cd rush && cargo clean && cargo build --release
+
+minimal: rush # Build Docker image: syntheticnet:minimal
+	$(DOCKER) build -t syntheticnet:minimal -f Dockerfile.minimal .
+
 run-interactive: image synthetic-network # Debug syntheticnet container. Prereq: create-synthetic-network
 	$(DOCKER) rm $(CONTAINER_NAME_INTERACTIVE) || true
 	$(DOCKER) create --privileged \
@@ -59,6 +65,6 @@ synthetic-network: # Specify SYNTHETIC_NETWORK (this rule is documentation)
 create-synthetic-network: synthetic-network # Create Docker network: synthetic-network
 	$(DOCKER) network create synthetic-network --subnet=$(SYNTHETIC_NETWORK)
 
-.PHONY: image image-vnc image-chrome \
+.PHONY: image image-vnc image-chrome minimal rush \
 run-interactive run-chrome \
 synthetic-network create-synthetic-network

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ help: # Print this help message
 image: # Build Docker image: syntheticnet
 image-vnc: # Build Docker image: syntheticnet:vnc
 image-chrome: image-vnc # Build Docker image: syntheticnet:chrome
+rush: # Build rush
+minimal: rush # Build Docker image: syntheticnet:minimal
 run-interactive: image synthetic-network # Debug syntheticnet container. Prereq: create-synthetic-network
 run-chrome: image-chrome synthetic-network # Run syntheticnet:chrome. Prereq: create-synthetic-network
 synthetic-network: # Specify SYNTHETIC_NETWORK (this rule is documentation)
@@ -57,6 +59,55 @@ Build `syntheticnet` image
 with VNC:
 
 ```$ make image-vnc```
+
+It is also possible to build a minimal image with:
+
+```$ make minimal```
+
+The `minimal` image doesn't have a frontend to update the user network proxy
+(`rush`) settings (see example below). Instead, one needs to use the `QOS_SPEC`
+environment variable to point to a configuration file. One way to add that
+configuration file is by creating a new image based on the `minimal` image.
+
+### Rush settings example
+
+[`rush/`](rush) is the packet processing framework we use to handle bandwidth,
+packet loss, jitter, etc. This is an example configuration:
+
+```
+{
+  "default_link": {
+    "ingress": {
+      "rate": 10000000,
+      "loss": 0,
+      "latency": 0,
+      "jitter": 0,
+      "jitter_strength": 0,
+      "reorder_packets": false
+    },
+    "egress": {
+      "rate": 10000000,
+      "loss": 0.02,
+      "latency": 0,
+      "jitter": 0,
+      "jitter_strength": 0,
+      "reorder_packets": false
+    }
+  },
+  "flows": []
+}
+```
+
+Where we define a 10Mbps ingress and egress network and a 2% packet loss on
+egress. We can also specify settings per each protocol, an example can be
+obtained running `rush` help:
+
+```
+make rush
+cd rush
+cargo build --release
+./target/release/rush -h
+```
 
 ## Scripting the Synthetic Network
 

--- a/rush/rust-toolchain.toml
+++ b/rush/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/setup.sh
+++ b/setup.sh
@@ -84,21 +84,22 @@ mkdir -p $(dirname $qos_spec)
 # Set initial QoS spec. The user can provide a default QoS spec file using the
 # QOS_SPEC environment variable.
 if [ -z "$QOS_SPEC" ]; then
-    /opt/lib/rush/target/release/rush -h | grep "Example config" | awk '{print $5}' > $qos_spec
+    /opt/lib/rush -h | grep "Example config" | awk '{print $5}' > $qos_spec
 else
     cp -f $QOS_SPEC $qos_spec
 fi
 
 # Start rush (userspace network proxy) bridging $dev<->veth0
-/opt/lib/rush/target/release/rush \
-    $dev veth0 $qos_spec $ingress_profile $egress_profile &
+/opt/lib/rush $dev veth0 $qos_spec $ingress_profile $egress_profile &
 rushpid=$!
 # Trigger reload of $qos_spec with
 #   kill -s SIGHUP $rushpid
 
 # Start frontend listening on port 80
-(cd /opt/lib/frontend/;
- node start.js $qos_spec $rushpid $ingress_profile $egress_profile 80) &
+if [ -d "/opt/lib/frontend/" ]; then
+    (cd /opt/lib/frontend/;
+     node start.js $qos_spec $rushpid $ingress_profile $egress_profile 80) &
+fi
 
 
 # Run tests!


### PR DESCRIPTION
The `minimal` target will build the smallest synthetic-network image for the
rush user proxy to work. This means no frontend is available.

Since there is no frontend available this requires the use of QOS_SPEC
environment variable in order to initialize rush with the right settings.

(Needs to be rebased on top of #8 once that's merged)