### PR TITLE
FIX: upgraded docker-image `node:12.20.2` in Dockerfile to `node:20.3.0-bookworm`

### DIFF
--- a/rush/rust-toolchain.toml
+++ b/rush/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-10-30"


### PR DESCRIPTION
After recent release of Debian, provided Dockerfile is no longer able to build the project, so bumped its version. Additionally, I've split the Dockerfile into logical `build` and `execute synthetic-network` parts. I've also fixed some version of the rust's nightly toolchain yoiu're using - far from perfect but more `stable` option.